### PR TITLE
Update iOS headers for React Native 0.40

### DIFF
--- a/example/ios/SnackbarExample/AppDelegate.m
+++ b/example/ios/SnackbarExample/AppDelegate.m
@@ -9,8 +9,8 @@
 
 #import "AppDelegate.h"
 
-#import "RCTBundleURLProvider.h"
-#import "RCTRootView.h"
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
 
 @implementation AppDelegate
 

--- a/example/ios/SnackbarExampleTests/SnackbarExampleTests.m
+++ b/example/ios/SnackbarExampleTests/SnackbarExampleTests.m
@@ -10,8 +10,8 @@
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
 
-#import "RCTLog.h"
-#import "RCTRootView.h"
+#import <React/RCTLog.h>
+#import <React/RCTRootView.h>
 
 #define TIMEOUT_SECONDS 600
 #define TEXT_TO_LOOK_FOR @"Welcome to React Native!"

--- a/ios/RNSnackBarView.m
+++ b/ios/RNSnackBarView.m
@@ -7,7 +7,7 @@
 //
 
 #import "RNSnackBarView.h"
-#import "RCTConvert.h"
+#import <React/RCTConvert.h>
 
 typedef NS_ENUM(NSInteger, RNSnackBarViewState) {
   RNSnackBarViewStateDisplayed,
@@ -80,14 +80,14 @@ static const NSTimeInterval ANIMATION_DURATION = 0.250;
     titleLabel.font = [UIFont boldSystemFontOfSize:14];
     [titleLabel setTranslatesAutoresizingMaskIntoConstraints:NO];
     [self addSubview:titleLabel];
-  
+
     actionButton = [UIButton new];
     actionButton.titleLabel.font = [UIFont boldSystemFontOfSize:16];
     [actionButton setTitle:@"" forState:UIControlStateNormal];
     [actionButton addTarget:self action:@selector(actionPressed:) forControlEvents:UIControlEventTouchUpInside];
     [actionButton setTranslatesAutoresizingMaskIntoConstraints:NO];
     [self addSubview:actionButton];
-  
+
     [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:
           @"H:|-24-[titleLabel]-24-[actionButton]-24-|"
           options:0 metrics:nil views:@{@"titleLabel": titleLabel, @"actionButton": actionButton}]];
@@ -164,7 +164,7 @@ static const NSTimeInterval ANIMATION_DURATION = 0.250;
         }
     }];
 }
-  
+
 - (void)show {
     if (self.state == RNSnackBarViewStateDisplayed || self.state == RNSnackBarViewStatePresenting) {
       [self dismiss];
@@ -174,7 +174,7 @@ static const NSTimeInterval ANIMATION_DURATION = 0.250;
       return;
     }
     if (!_pendingOptions) { return; }
-  
+
     self.title = _pendingOptions[@"title"];
     self.callback = _pendingCallback;
     NSDictionary* action = _pendingOptions[@"action"];

--- a/ios/RNSnackbar.h
+++ b/ios/RNSnackbar.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Facebook. All rights reserved.
 //
 
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 #import <Foundation/Foundation.h>
 
 @interface RNSnackbar : NSObject<RCTBridgeModule>

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
   "homepage": "https://github.com/cooperka/react-native-snackbar",
   "devDependencies": {
     "react": "~15.4.1",
-    "react-native": "~0.39.2"
+    "react-native": "~0.40.0"
   }
 }


### PR DESCRIPTION
- Also update React Native version dependency to 0.40 in package.json.
- This will break <0.40 compatibility for the next release, so this should be noted if
  appropriate when setting the next release.