### PR TITLE
Fix Android modals not showing snackbar

### DIFF
--- a/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
+++ b/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
@@ -115,7 +115,7 @@ public class SnackbarModule extends ReactContextBaseJavaModule{
             final View child = view.getChildAt(i);
 
             if (child instanceof ViewGroup) {
-                return recursiveLoopChildren((ViewGroup) child, modals);
+                recursiveLoopChildren((ViewGroup) child, modals);
             }
         }
 


### PR DESCRIPTION
The `return` is breaking the search of modals view in all the children views. It is only searching in the first children. This PR fixes that issue.