### PR TITLE
React Native 0.47 Compatibility

### DIFF
--- a/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarPackage.java
+++ b/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarPackage.java
@@ -16,7 +16,6 @@ public class SnackbarPackage implements ReactPackage {
         return Collections.<NativeModule>singletonList((new SnackbarModule(reactContext)));
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarPackage.java
+++ b/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarPackage.java
@@ -16,6 +16,8 @@ public class SnackbarPackage implements ReactPackage {
         return Collections.<NativeModule>singletonList((new SnackbarModule(reactContext)));
     }
 
+    // This "Override" method is being kept for backwards compatibilty with React Native
+    // releases earlier than https://github.com/facebook/react-native/releases/tag/v0.47.0
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Remove override annotation for createJSModules for compatibility which resolves #39 