### PR TITLE
Add an accessibility identifier to the snackbar

### DIFF
--- a/ios/RNSnackBarView.m
+++ b/ios/RNSnackBarView.m
@@ -78,6 +78,8 @@ static const NSTimeInterval ANIMATION_DURATION = 0.250;
 
 - (void)buildView {
     self.backgroundColor = [UIColor colorWithRed:0.196078F green:0.196078F blue:0.196078F alpha:1.0F];
+    self.accessibilityIdentifier = @"snackbar";
+  
     titleLabel = [UILabel new];
     titleLabel.text = _title;
     titleLabel.numberOfLines = 2;


### PR DESCRIPTION
It's pretty much impossible to identify the snackbar by class from UI tests the way Apple has created them.

This accessibility identifier should help identify the snackbar so that tests can be written to wait for the snackbar to show up or disappear.