### PR TITLE
fix(ios): Require mainQueue to remove warnings in 0.50

### DIFF
--- a/ios/RNSnackbar.m
+++ b/ios/RNSnackbar.m
@@ -29,6 +29,11 @@ RCT_EXPORT_METHOD(dismiss)
     });
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 - (NSDictionary *)constantsToExport
 {
     return @{


### PR DESCRIPTION
Module RNSnackbar requires main queue setup since it overrides
`constantsToExport` but doesn't implement `requiresMainQueueSetup. In a
future release React Native will default to initializing all native
modules on a background thread unless explicitly opted-out of.

Closes #50