### PR TITLE
Fix NativeModules.RNSnackbar being undefined during testing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ type ISnackBar = {
   dismiss: () => void,
 };
 
-const SnackBar: ISnackBar = {
+const SnackBar: ISnackBar = NativeModules.RNSnackbar ? {
 
   LENGTH_LONG: NativeModules.RNSnackbar.LENGTH_LONG,
   LENGTH_SHORT: NativeModules.RNSnackbar.LENGTH_SHORT,
@@ -51,6 +51,6 @@ const SnackBar: ISnackBar = {
     NativeModules.RNSnackbar.dismiss();
   },
 
-};
+} : {};
 
 export default SnackBar;


### PR DESCRIPTION


## problem

Test fails with NativeModules.RNSnackbar undefined.

```
Cannot read property 'LENGTH_LONG' of undefined
```

## env

- react-native 0.47.1
- react-native-snackbar 0.4.4

## fixes

Fix to not use if undefined.

## related issues

- [Cannot read property 'LENGTH_LONG' of undefined](https://github.com/cooperka/react-native-snackbar/issues/43)
