### PR TITLE
Update build.gradle to support RNv56

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,13 +9,20 @@ buildscript {
 
 apply plugin: "com.android.library"
 
+def _ext = rootProject.ext
+def _reactNativeVersion = _ext.has('reactNative') ? _ext.reactNative : '+'
+def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 25
+def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '25.0.2'
+def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 16
+def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 25
+
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion _compileSdkVersion
+    buildToolsVersion _buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 25
+        minSdkVersion _minSdkVersion
+        targetSdkVersion _targetSdkVersion
         versionCode 1
         versionName "1.0"
     }
@@ -32,7 +39,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+' // from node_modules
+    compile "com.facebook.react:react-native:${_reactNativeVersion}"
 
     compile 'com.android.support:appcompat-v7:25.1.0'
     compile 'com.android.support:support-v4:25.1.0'


### PR DESCRIPTION
This PR is to support React Native v56. As discussed in https://github.com/cooperka/react-native-snackbar/issues/83 I have tested this change and now I am pointing to my fork in order to successfully build my project. From my tests snackbar has been working as intended throughout the entire app.