### PR TITLE
Don't display Snackbar if view is `null` (android only)

### DIFF
--- a/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
+++ b/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
@@ -64,6 +64,8 @@ public class SnackbarModule extends ReactContextBaseJavaModule{
             ArrayList<View> modals = recursiveLoopChildren(view, new ArrayList<View>());
 
             for (View modalViews : modals) {
+                if (modalViews == null) continue;
+
                 displaySnackbar(modalViews, options, callback);
             }
 


### PR DESCRIPTION
That hotfix should prevent fantom crashes on android #93 