### PR TITLE
Enable title coloring

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Snackbar.show({
 | `duration` | See below | `Snackbar.LENGTH_SHORT` | How long to display the Snackbar. |
 | `action` | `object` (described below) | `undefined` (no button) | Optional config for the action button (described below). |
 | `backgroundColor` | `string` or `style` | `undefined` (natively renders as black) | The background color for the whole Snackbar. |
+| `color` | `string` or `style` | `undefined` (natively renders as white) | The text color for the title. |
 
 Where `duration` can be one of the following (timing may vary based on device):
 

--- a/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
+++ b/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
@@ -118,9 +118,9 @@ public class SnackbarModule extends ReactContextBaseJavaModule{
         }
 
         if (options.hasKey("color")) {
-          View snackbarView = snackbar.getView();
-          TextView snackbarText = (TextView) snackbarView.findViewById(android.support.design.R.id.snackbar_text);
-          snackbarText.setTextColor(options.getInt("color"));
+            View snackbarView = snackbar.getView();
+            TextView snackbarText = (TextView) snackbarView.findViewById(android.support.design.R.id.snackbar_text);
+            snackbarText.setTextColor(options.getInt("color"));
         }
 
         // For older devices, explicitly set the text color; otherwise it may appear dark gray.

--- a/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
+++ b/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
@@ -92,7 +92,7 @@ public class SnackbarModule extends ReactContextBaseJavaModule{
 
         Snackbar snackbar = Snackbar.make(view, title, duration);
         View snackbarView = snackbar.getView();
-        TextView snackbarText = (TextView) snackbarView.findViewById(android.support.design.R.id.snackbar_text);
+        TextView snackbarText = snackbarView.findViewById(android.support.design.R.id.snackbar_text);
 
         mActiveSnackbars.add(snackbar);
 
@@ -122,11 +122,9 @@ public class SnackbarModule extends ReactContextBaseJavaModule{
 
         if (options.hasKey("color")) {
             snackbarText.setTextColor(options.getInt("color"));
-        }
-
-        // For older devices, explicitly set the text color; otherwise it may appear dark gray.
-        // http://stackoverflow.com/a/31084530/763231
-        if (!options.hasKey("color") && Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+        } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            // For older devices, explicitly set the text color; otherwise it may appear dark gray.
+            // http://stackoverflow.com/a/31084530/763231
             snackbarText.setTextColor(Color.WHITE);
         }
 

--- a/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
+++ b/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
@@ -117,9 +117,15 @@ public class SnackbarModule extends ReactContextBaseJavaModule{
             snackbar.setActionTextColor(actionDetails.getInt("color"));
         }
 
+        if (options.hasKey("color")) {
+          View snackbarView = snackbar.getView();
+          TextView snackbarText = (TextView) snackbarView.findViewById(android.support.design.R.id.snackbar_text);
+          snackbarText.setTextColor(options.getInt("color"));
+        }
+
         // For older devices, explicitly set the text color; otherwise it may appear dark gray.
         // http://stackoverflow.com/a/31084530/763231
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+        if (!options.hasKey("color") && Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
             View snackbarView = snackbar.getView();
             TextView snackbarText = (TextView) snackbarView.findViewById(android.support.design.R.id.snackbar_text);
             snackbarText.setTextColor(Color.WHITE);

--- a/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
+++ b/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
@@ -91,11 +91,14 @@ public class SnackbarModule extends ReactContextBaseJavaModule{
         int duration = options.hasKey("duration") ? options.getInt("duration") : Snackbar.LENGTH_SHORT;
 
         Snackbar snackbar = Snackbar.make(view, title, duration);
+        View snackbarView = snackbar.getView();
+        TextView snackbarText = (TextView) snackbarView.findViewById(android.support.design.R.id.snackbar_text);
+
         mActiveSnackbars.add(snackbar);
 
         // Set the background color.
         if (options.hasKey("backgroundColor")) {
-            snackbar.getView().setBackgroundColor(options.getInt("backgroundColor"));
+            snackbarView.setBackgroundColor(options.getInt("backgroundColor"));
         }
 
         if (options.hasKey("action")) {
@@ -118,16 +121,12 @@ public class SnackbarModule extends ReactContextBaseJavaModule{
         }
 
         if (options.hasKey("color")) {
-            View snackbarView = snackbar.getView();
-            TextView snackbarText = (TextView) snackbarView.findViewById(android.support.design.R.id.snackbar_text);
             snackbarText.setTextColor(options.getInt("color"));
         }
 
         // For older devices, explicitly set the text color; otherwise it may appear dark gray.
         // http://stackoverflow.com/a/31084530/763231
         if (!options.hasKey("color") && Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            View snackbarView = snackbar.getView();
-            TextView snackbarText = (TextView) snackbarView.findViewById(android.support.design.R.id.snackbar_text);
             snackbarText.setTextColor(Color.WHITE);
         }
 

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -54,10 +54,11 @@ class Example extends Component {
             title: 'Please agree to this.',
             duration: Snackbar.LENGTH_INDEFINITE,
             backgroundColor: 'silver',
+            color: 'blue',
             action: {
               title: 'AGREE',
               onPress: () => Snackbar.show({ title: 'Thank you!' }),
-              color: 'gold',
+              color: 'blue',
             },
           })}
         >

--- a/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/__tests__/__snapshots__/index.test.js.snap
@@ -3,7 +3,11 @@
 exports[`Snackbar module calls native with default params 1`] = `
 Array [
   Array [
-    Object {},
+    Object {
+      "action": undefined,
+      "backgroundColor": undefined,
+      "color": undefined,
+    },
     [Function],
   ],
 ]
@@ -18,6 +22,8 @@ Array [
         "onPress": [MockFunction],
         "title": "UNDO",
       },
+      "backgroundColor": undefined,
+      "color": undefined,
       "duration": 0,
       "title": "Hello world",
     },

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ type Action = {
 type SnackBarOptions = {
   title: string,
   duration?: number,
+  color?: string | number,
   backgroundColor?: string,
   action?: Action,
 };
@@ -34,11 +35,13 @@ const SnackBar: ISnackBar = {
     const onPressCallback = action.onPress || (() => {});
     const actionColor = action.color && processColor(action.color);
     const backgroundColor = options.backgroundColor && processColor(options.backgroundColor);
+    const color = options.color && processColor(options.color);
 
     const snackConfig = {
       ...options,
       action: { ...action, color: actionColor },
       backgroundColor,
+      color,
     };
 
     NativeModules.RNSnackbar.show(snackConfig, onPressCallback);

--- a/src/index.js
+++ b/src/index.js
@@ -30,21 +30,18 @@ const SnackBar: ISnackBar = {
   LENGTH_INDEFINITE: NativeModules.RNSnackbar.LENGTH_INDEFINITE,
 
   show(options: SnackBarOptions) {
-    const onPressCallback = (options.action && options.action.onPress) || (() => {});
+    const action = options.action || {};
+    const onPressCallback = action.onPress || (() => {});
+    const actionColor = action.color && processColor(action.color);
+    const backgroundColor = options.backgroundColor && processColor(options.backgroundColor);
 
-    if (options.action && options.action.color) {
-      /* eslint-disable no-param-reassign */
-      // $FlowFixMe
-      options.action.color = processColor(options.action.color);
-      /* eslint-enable */
-    }
+    const snackConfig = {
+      ...options,
+      action: { ...action, color: actionColor },
+      backgroundColor,
+    };
 
-    if (options.backgroundColor) {
-      // eslint-disable-next-line no-param-reassign
-      options.backgroundColor = processColor(options.backgroundColor);
-    }
-
-    NativeModules.RNSnackbar.show(options, onPressCallback);
+    NativeModules.RNSnackbar.show(snackConfig, onPressCallback);
   },
 
   dismiss() {

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ const SnackBar: ISnackBar = {
 
     const snackConfig = {
       ...options,
-      action: { ...action, color: actionColor },
+      action: options.action ? { ...action, color: actionColor } : undefined,
       backgroundColor,
       color,
     };


### PR DESCRIPTION
Related #47

This enables changing the snackbar title color on Android, which is likely a requirement if your app's theme defines a dark value for `textColor` (doing so overrides the default white color of the title and sets its color to `textColor`). 

This pull request does not yet include the equivalent changes for iOS, which I'm unable to work on and verify at the moment. I'm opening this for visibility so someone can take it the rest of the way if they come across it before I have the chance.