### PR TITLE
Allow the title to use the full width of the snackbar on iOS when there is no action

### DIFF
--- a/ios/RNSnackBarView.m
+++ b/ios/RNSnackBarView.m
@@ -23,6 +23,7 @@ static const NSTimeInterval ANIMATION_DURATION = 0.250;
 {
     UILabel* titleLabel;
     UIButton* actionButton;
+    NSArray* horizontalLayoutConstraints;
     NSTimer* dismissTimer;
 }
 @property (nonatomic, strong) NSDictionary* pendingOptions;
@@ -90,7 +91,7 @@ static const NSTimeInterval ANIMATION_DURATION = 0.250;
 
     self.backgroundColor = [UIColor colorWithRed:0.196078F green:0.196078F blue:0.196078F alpha:1.0F];
     self.accessibilityIdentifier = @"snackbar";
-  
+
     titleLabel = [UILabel new];
     titleLabel.text = _title;
     titleLabel.numberOfLines = 2;
@@ -106,19 +107,33 @@ static const NSTimeInterval ANIMATION_DURATION = 0.250;
     [actionButton setTranslatesAutoresizingMaskIntoConstraints:NO];
     [self addSubview:actionButton];
 
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:
-          @"H:|-24-[titleLabel]-24-[actionButton]-24-|"
-          options:0 metrics:nil views:@{@"titleLabel": titleLabel, @"actionButton": actionButton}]];
     [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:[NSString stringWithFormat:@"V:|-%f-[titleLabel]-%f-|", topPadding, bottomPadding] options:0 metrics:nil views:@{@"titleLabel": titleLabel}]];
     [self addConstraint:[NSLayoutConstraint constraintWithItem:actionButton attribute:NSLayoutAttributeCenterY relatedBy:NSLayoutRelationEqual toItem:titleLabel attribute:NSLayoutAttributeCenterY multiplier:1 constant:0]];
     [titleLabel setContentCompressionResistancePriority:250 forAxis:UILayoutConstraintAxisHorizontal];
     [titleLabel setContentHuggingPriority:250 forAxis:UILayoutConstraintAxisHorizontal];
     [actionButton setContentCompressionResistancePriority:750 forAxis:UILayoutConstraintAxisHorizontal];
     [actionButton setContentHuggingPriority:750 forAxis:UILayoutConstraintAxisHorizontal];
+
+    self.actionHidden = YES;
 }
 
 -(void)setTitle:(NSString *)title {
     titleLabel.text = title;
+}
+
+-(void)setActionHidden:(BOOL)hidden {
+    if (actionButton.hidden != hidden || horizontalLayoutConstraints == nil) {
+        actionButton.hidden = hidden;
+        if (horizontalLayoutConstraints != nil) {
+            [self removeConstraints:horizontalLayoutConstraints];
+        }
+        if (hidden) {
+            horizontalLayoutConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"H:|-24-[titleLabel]-24-|" options:0 metrics:nil views:@{@"titleLabel": titleLabel}];
+        } else {
+            horizontalLayoutConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"H:|-24-[titleLabel]-24-[actionButton]-24-|" options:0 metrics:nil views:@{@"titleLabel": titleLabel, @"actionButton": actionButton}];
+        }
+        [self addConstraints:horizontalLayoutConstraints];
+    }
 }
 
 -(void)setTitleColor:(UIColor *)titleColor {
@@ -215,10 +230,12 @@ static const NSTimeInterval ANIMATION_DURATION = 0.250;
     NSDictionary* action = _pendingOptions[@"action"];
     if (action) {
         self.actionTitle = _pendingOptions[@"action"][@"title"];
+        self.actionHidden = _pendingOptions[@"action"][@"title"] ? NO : YES;
         NSNumber* color = _pendingOptions[@"action"][@"color"];
         self.actionTitleColor = [RCTConvert UIColor:color];
     } else {
         self.actionTitle = @"";
+        self.actionHidden = YES;
     }
 
     NSNumber* duration = _pendingOptions[@"duration"]


### PR DESCRIPTION
This is to fix the snackbar action button still taking up space when there's no action

Without an action:

![image](https://user-images.githubusercontent.com/292417/52709769-9183ca80-2f85-11e9-946c-d4056ad3cf2b.png)

With an action, multi-line:

![image](https://user-images.githubusercontent.com/292417/52709771-947ebb00-2f85-11e9-8d79-e77718e2e161.png)

With an action, single line:

![image](https://user-images.githubusercontent.com/292417/52709784-9ea0b980-2f85-11e9-981c-e7e0f2b6a827.png)
