### PR TITLE
Change 'compile' to 'implementation'

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,9 +50,9 @@ repositories {
 }
 
 dependencies {
-    compile "com.facebook.react:react-native:${_reactNativeVersion}"
+    implementation "com.facebook.react:react-native:${_reactNativeVersion}"
 
-    compile "com.android.support:appcompat-v7:${_supportLibVersion}"
-    compile "com.android.support:support-v4:${_supportLibVersion}"
-    compile "com.android.support:design:${_supportLibVersion}"
+    implementation "com.android.support:appcompat-v7:${_supportLibVersion}"
+    implementation "com.android.support:support-v4:${_supportLibVersion}"
+    implementation "com.android.support:design:${_supportLibVersion}"
 }


### PR DESCRIPTION
As of Android Gradle Plugin 3.0.0, `compile` has been deprecated in favor of `implementation`

> Using this dependency configuration instead of `api` or `compile` (deprecated) can result in significant build time improvements because it reduces the number of modules that the build system needs to recompile. 

http://d.android.com/r/tools/update-dependency-configurations.html