### PR TITLE
feat: Update typescript pipeline

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,5 @@ android
 ios
 
 lib
+src/index.d.ts
+src/__tests__/types.ts

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,5 @@ script:
 # Ignoring flow for now because it just fails on all sorts of React Native issues.
 # - yarn run flow
  - yarn test -- --cacheDirectory="jest-cache"
+ - yarn test:types
  - cd example && yarn test -- --cacheDirectory="jest-cache2"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   ],
   "scripts": {
     "test": "jest",
+    "test:types": "tsc",
     "lint": "eslint . --ext .js,.jsx",
     "flow": "flow src",
     "clean": "rm -rf lib",
@@ -65,6 +66,7 @@
     "eslint-plugin-react-native": "3.2.1",
     "jest": "23.5.0",
     "react": "16.4.1",
-    "react-native": "0.56"
+    "react-native": "0.56",
+    "typescript": "^3.5.3"
   }
 }

--- a/src/__tests__/types.ts
+++ b/src/__tests__/types.ts
@@ -1,0 +1,43 @@
+import Snackbar, { SnackBarOptions, SnackbarAction, SnackbarStatic } from '..';
+
+/**
+ * Duration Short, required properties only
+ */
+Snackbar.show({
+  title: 'Hello world',
+  duration: Snackbar.LENGTH_SHORT,
+});
+
+/**
+ * Duration Long, Action with optional properties added
+ */
+Snackbar.show({
+  title: 'Hello world',
+  duration: Snackbar.LENGTH_LONG,
+  backgroundColor: 'pink',
+  color: 'red',
+});
+
+/**
+ * Duration Indefinite, Action with required properties only
+ */
+Snackbar.show({
+  title: 'Hello world',
+  duration: Snackbar.LENGTH_INDEFINITE,
+  action: {
+    title: 'Undo',
+  },
+});
+
+/**
+ * Duration Indefinite, Action with custom properties added
+ */
+Snackbar.show({
+  title: 'Hello world',
+  duration: Snackbar.LENGTH_INDEFINITE,
+  action: {
+    title: 'Undo',
+    color: 'red',
+    onPress: () => {},
+  },
+});

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,12 +1,7 @@
-// Type definitions for react-native-snackbar 0.3.4
-// Project: https://github.com/cooperka/react-native-snackbar
-// Definitions by: Kyle Roach <https://github.com/iRoachie>
-// TypeScript Version: 2.2.2
-
 /**
  * An actionable button that can be shown on the Snackbar.
  */
-interface Action {
+export interface SnackbarAction {
   /**
    * Text for the button.
    */
@@ -27,7 +22,7 @@ interface Action {
 /**
  * List of options to configure the Snackbar.
  */
-interface SnackBarOptions {
+export interface SnackBarOptions {
   /**
    * The text that appears on the Snackbar.
    */
@@ -54,13 +49,13 @@ interface SnackBarOptions {
   /**
    * Adds an actionable button to the snackbar on the right
    */
-  action?: Action;
+  action?: SnackbarAction;
 }
 
 /**
  * Snackbar definition
  */
-interface Snackbar{
+export interface SnackbarStatic {
   /**
    * Snackbar duration of about a second.
    */
@@ -89,5 +84,5 @@ interface Snackbar{
   dismiss(): void;
 }
 
-export const SnackbarInstance: Snackbar
-export default SnackbarInstance;
+declare const Snackbar: SnackbarStatic;
+export default Snackbar;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "strict": true
+  },
+  "include": ["src/__tests__/types.ts"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6484,6 +6484,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typescript@^3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
+  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
+
 ua-parser-js@^0.7.18, ua-parser-js@^0.7.9:
   version "0.7.18"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"


### PR DESCRIPTION
## Motivation
Reduce the issues and long discussions around types in https://github.com/cooperka/react-native-snackbar/pull/111 https://github.com/cooperka/react-native-snackbar/pull/106

## Solution
Some small housekeeping on different areas:
- Exports all interfaces used https://github.com/cooperka/react-native-snackbar/pull/111#issuecomment-509549617. This is best practice in the industry. As a result, renamed the `Action` interface to `SnackbarAction` so it reflects where it's from. Also renames `Snackbar` to `SnackbarStatic` which is the naming convention (See React Native's Alert for example https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-native/index.d.ts#L7011).

- Removes the header at the top as that's only required for definitions hosted on DefinitelyTyped. Forgot to remove this when I ported the definitions.

- Fixed the definitions to work correctly. The attempt in #111 was good but it does an incorrect export at https://github.com/cooperka/react-native-snackbar/blob/master/src/index.d.ts#L92. This allows `import { Snackbar } from 'react-native-snackbar'` which is incorrect. Instead it the const should be declared and default exported.

- Lastly adds a typescript test that'll test definitions in ci so we don’t have these problems going forward.