### PR TITLE
Update README.md with the maximum of characters in title.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Snackbar.show({
 
 | Key | Data type | Default value? | Description |
 |-----|-----------|----------------|-------------|
-| `title` | `string` | Required. | The message to show. |
+| `title` | `string` | Required. | The message to show. (max characters: 70) | 
 | `duration` | See below | `Snackbar.LENGTH_SHORT` | How long to display the Snackbar. |
 | `action` | `object` (described below) | `undefined` (no button) | Optional config for the action button (described below). |
 | `backgroundColor` | `string` or `style` | `undefined` (natively renders as black) | The background color for the whole Snackbar. |

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Snackbar.show({
 
 | Key | Data type | Default value? | Description |
 |-----|-----------|----------------|-------------|
-| `title` | `string` | Required. | The message to show. (max characters: 70) | 
+| `title` | `string` | Required. | The message to show. | 
 | `duration` | See below | `Snackbar.LENGTH_SHORT` | How long to display the Snackbar. |
 | `action` | `object` (described below) | `undefined` (no button) | Optional config for the action button (described below). |
 | `backgroundColor` | `string` or `style` | `undefined` (natively renders as black) | The background color for the whole Snackbar. |
@@ -79,6 +79,8 @@ And the optional `action` object can contain the following options:
 | `title` | `string` | Required. | The text to show on the button. |
 | `onPress` | `function` | `undefined` (Snackbar is simply dismissed) | A callback for when the user taps the button. |
 | `color` | `string` or `style` | `undefined` (natively renders as white) | The text color for the button. |
+
+Note: the `title` will ellipsize after 2 lines of text on most platforms. See #110 if you need to display more lines.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Snackbar.show({
 
 | Key | Data type | Default value? | Description |
 |-----|-----------|----------------|-------------|
-| `title` | `string` | Required. | The message to show. | 
+| `title` | `string` | Required. | The message to show. |
 | `duration` | See below | `Snackbar.LENGTH_SHORT` | How long to display the Snackbar. |
 | `action` | `object` (described below) | `undefined` (no button) | Optional config for the action button (described below). |
 | `backgroundColor` | `string` or `style` | `undefined` (natively renders as black) | The background color for the whole Snackbar. |

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ And the optional `action` object can contain the following options:
 | `onPress` | `function` | `undefined` (Snackbar is simply dismissed) | A callback for when the user taps the button. |
 | `color` | `string` or `style` | `undefined` (natively renders as white) | The text color for the button. |
 
-Note: the `title` will ellipsize after 2 lines of text on most platforms. See #110 if you need to display more lines.
+Note: the `title` will ellipsize after 2 lines of text on most platforms. See [#110](https://github.com/cooperka/react-native-snackbar/issues/110) if you need to display more lines.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Description 
The snack bar just allows setting 70 characters, after that it sets three dots.
![image](https://user-images.githubusercontent.com/26729748/62132239-4e52b500-b2a2-11e9-8d79-b5afaa796fcc.png)
We should consider this for future implementations.