### PR TITLE
fix: Fallback color for title

### DIFF
--- a/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
+++ b/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
@@ -122,9 +122,7 @@ public class SnackbarModule extends ReactContextBaseJavaModule{
 
         if (options.hasKey("color")) {
             snackbarText.setTextColor(options.getInt("color"));
-        } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            // For older devices, explicitly set the text color; otherwise it may appear dark gray.
-            // http://stackoverflow.com/a/31084530/763231
+        } else {
             snackbarText.setTextColor(Color.WHITE);
         }
 


### PR DESCRIPTION
Set title color to white if none is provided
Fixes #125