### PR TITLE
Support margin bottom/left/right for iOS

### DIFF
--- a/ios/RNSnackBarView.m
+++ b/ios/RNSnackBarView.m
@@ -176,19 +176,25 @@ static const NSTimeInterval ANIMATION_DURATION = 0.250;
 }
 
 - (void)presentWithDuration:(NSNumber *)duration {
+    
+      NSString* left= [NSString stringWithFormat:@"%@",_pendingOptions[@"left"]] ? [NSString stringWithFormat:@"%@",_pendingOptions[@"left"]] : @"0.0";
+    NSString* right= [NSString stringWithFormat:@"%@",_pendingOptions[@"right"]] ? [NSString stringWithFormat:@"%@",_pendingOptions[@"right"]] : @"0.0";
+    NSString* bottom= [NSString stringWithFormat:@"%@",_pendingOptions[@"bottom"]] ? [NSString stringWithFormat:@"%@",_pendingOptions[@"bottom"]] : @"0.0";
+    
+    
+    float leftVal = [left floatValue];
+    float rightVal = [right floatValue];
+    float bottomVal = [bottom floatValue];
+
+    
     _pendingOptions = nil;
     _pendingCallback = nil;
     UIWindow *keyWindow = [UIApplication sharedApplication].keyWindow;
     [keyWindow addSubview:self];
     [self setTranslatesAutoresizingMaskIntoConstraints:false];
-    [keyWindow addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[self(>=48)]|"
-                                                                      options:0
-                                                                      metrics:nil
-                                                                        views:@{@"self" : self}]];
-    [keyWindow addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[self]|"
-                                                                      options:0
-                                                                      metrics:nil
-                                                                        views:@{@"self" : self}]];
+    [keyWindow addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:[NSString stringWithFormat:@"H:|-%f-[self]-%f-|", leftVal, rightVal] options:0 metrics:nil views:@{@"self": self}]];
+
+     [keyWindow addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:[NSString stringWithFormat:@"V:[self]-%f-|", bottomVal] options:0 metrics:nil views:@{@"self": self}]];
 
     self.transform = CGAffineTransformMakeTranslation(0, self.bounds.size.height);
     textLabel.alpha = 0;


### PR DESCRIPTION
Adding Margin for Bottom,Right and Left in IOS

How to use:
Include an action Button with Margin:

 Snackbar.show({
    title: "Your Message",
    left: 8,
    bottom: 8,
    right: 8,
    action: {
      title: "Dismiss",
      onPress: () => {
        /* Do something. */
        Snackbar.dismiss();
      }
    }
  });


Related to #15 