### PR TITLE
Handle invalid parent view

### DIFF
--- a/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
+++ b/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
@@ -104,7 +104,14 @@ public class SnackbarModule extends ReactContextBaseJavaModule {
             }
         }
 
-        Snackbar snackbar = Snackbar.make(view, text, duration);
+        Snackbar snackbar;
+        try {
+            snackbar = Snackbar.make(view, text, duration);
+        } catch (IllegalArgumentException e) {
+            // TODO: Fix root cause of "No suitable parent found from the given view. Please provide a valid view."
+            e.printStackTrace();
+            return;
+        }
         View snackbarView = snackbar.getView();
 
         if (rtl && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {

--- a/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
+++ b/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
@@ -52,30 +52,29 @@ public class SnackbarModule extends ReactContextBaseJavaModule {
 
         try {
             view = (ViewGroup) getCurrentActivity().getWindow().getDecorView().findViewById(android.R.id.content);
-
-            if (view == null) return;
-
-            mActiveSnackbars.clear();
-
-            if (!view.hasWindowFocus()) {
-                // The view is not focused, we should get all the modal views in the screen.
-                ArrayList<View> modals = recursiveLoopChildren(view, new ArrayList<View>());
-
-                for (View modal : modals) {
-                    if (modal == null) continue;
-
-                    displaySnackbar(modal, options, callback);
-                }
-
-                return;
-            }
-
-            displaySnackbar(view, options, callback);
-            
         } catch (Exception e) {
             e.printStackTrace();
             return;
         }
+
+        if (view == null) return;
+
+        mActiveSnackbars.clear();
+
+        if (!view.hasWindowFocus()) {
+            // The view is not focused, we should get all the modal views in the screen.
+            ArrayList<View> modals = recursiveLoopChildren(view, new ArrayList<View>());
+
+            for (View modal : modals) {
+                if (modal == null) continue;
+
+                displaySnackbar(modal, options, callback);
+            }
+
+            return;
+        }
+
+        displaySnackbar(view, options, callback);
     }
 
     @ReactMethod

--- a/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
+++ b/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
@@ -52,29 +52,30 @@ public class SnackbarModule extends ReactContextBaseJavaModule {
 
         try {
             view = (ViewGroup) getCurrentActivity().getWindow().getDecorView().findViewById(android.R.id.content);
+
+            if (view == null) return;
+
+            mActiveSnackbars.clear();
+
+            if (!view.hasWindowFocus()) {
+                // The view is not focused, we should get all the modal views in the screen.
+                ArrayList<View> modals = recursiveLoopChildren(view, new ArrayList<View>());
+
+                for (View modal : modals) {
+                    if (modal == null) continue;
+
+                    displaySnackbar(modal, options, callback);
+                }
+
+                return;
+            }
+
+            displaySnackbar(view, options, callback);
+            
         } catch (Exception e) {
             e.printStackTrace();
             return;
         }
-
-        if (view == null) return;
-
-        mActiveSnackbars.clear();
-
-        if (!view.hasWindowFocus()) {
-            // The view is not focused, we should get all the modal views in the screen.
-            ArrayList<View> modals = recursiveLoopChildren(view, new ArrayList<View>());
-
-            for (View modal : modals) {
-                if (modal == null) continue;
-
-                displaySnackbar(modal, options, callback);
-            }
-
-            return;
-        }
-
-        displaySnackbar(view, options, callback);
     }
 
     @ReactMethod


### PR DESCRIPTION
Takes care of this crash
```
Fatal Exception: java.lang.IllegalArgumentException: No suitable parent found from the given view. Please provide a valid view.
       at android.support.design.widget.Snackbar.make(Snackbar.java:181)
       at com.azendoo.reactnativesnackbar.SnackbarModule.displaySnackbar(SnackbarModule.java:93)
       at com.azendoo.reactnativesnackbar.SnackbarModule.show(SnackbarModule.java:69)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:372)
       at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:158)
       at com.facebook.react.bridge.queue.NativeRunnable.run(NativeRunnable.java)
       at android.os.Handler.handleCallback(Handler.java:873)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:29)
       at android.os.Looper.loop(Looper.java:193)
       at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:232)
       at java.lang.Thread.run(Thread.java:764)
```

Resolves #97