### PR TITLE
Use .npmignore instead of files field

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+/*
+!/src/
+!/lib/
+!/android/
+!/ios/
+!/RNSnackbar.podspec

--- a/package.json
+++ b/package.json
@@ -4,13 +4,6 @@
   "description": "Material Design \"Snackbar\" component for Android and iOS.",
   "main": "lib/index.js",
   "types": "src/index.d.ts",
-  "files": [
-    "src",
-    "lib",
-    "android",
-    "ios",
-    "RNSnackbar.podspec"
-  ],
   "scripts": {
     "test": "jest",
     "test:types": "tsc",


### PR DESCRIPTION
Fixes publication of extraneous files when using Yarn. See https://github.com/yarnpkg/yarn/issues/685#issuecomment-484304385.

You can compare npm’s and Yarn’s final packages by running [`npm pack`](https://docs.npmjs.com/cli-commands/pack.html) and [`yarn pack`](https://classic.yarnpkg.com/en/docs/cli/pack/). Don’t be surprised about some shallow differences as Yarn generates the package in a slightly different way.

Fixes #143.