### PR TITLE
Android: Display if view is not focused but no modals are shown either

### DIFF
--- a/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
+++ b/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
@@ -65,12 +65,15 @@ public class SnackbarModule extends ReactContextBaseJavaModule {
             // The view is not focused, we should get all the modal views in the screen.
             ArrayList<View> modals = recursiveLoopChildren(view, new ArrayList<View>());
 
-            for (View modal : modals) {
-                if (modal == null) continue;
+            if (modals.size() > 0) {
+                for (View modal : modals) {
+                    if (modal == null) continue;
 
-                displaySnackbar(modal, options, callback);
+                    displaySnackbar(modal, options, callback);
+                }
+            } else if (view.getVisibility() == View.VISIBLE) {
+                displaySnackbar(view, options, callback);
             }
-
             return;
         }
 

--- a/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
+++ b/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
@@ -73,6 +73,8 @@ public class SnackbarModule extends ReactContextBaseJavaModule {
                 }
             } else if (view.getVisibility() == View.VISIBLE) {
                 displaySnackbar(view, options, callback);
+            } else {
+                throw new Error("Content view is not in focus or not visible");
             }
             return;
         }

--- a/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
+++ b/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
@@ -5,6 +5,7 @@ import android.graphics.Typeface;
 import com.google.android.material.snackbar.Snackbar;
 
 import android.os.Build;
+import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
@@ -61,21 +62,26 @@ public class SnackbarModule extends ReactContextBaseJavaModule {
 
         mActiveSnackbars.clear();
 
+        // `hasWindowFocus`: Returns true if this activity's *main* window currently has window focus.
+        // Note that this is not the same as the view itself having focus.
         if (!view.hasWindowFocus()) {
-            // The view is not focused, we should get all the modal views in the screen.
+            // Get all modal views on the screen.
             ArrayList<View> modals = recursiveLoopChildren(view, new ArrayList<View>());
 
-            if (modals.size() > 0) {
-                for (View modal : modals) {
-                    if (modal == null) continue;
+            for (View modal : modals) {
+                if (modal == null) continue;
 
-                    displaySnackbar(modal, options, callback);
-                }
-            } else if (view.getVisibility() == View.VISIBLE) {
+                displaySnackbar(modal, options, callback);
+                return;
+            }
+
+            // No valid modals.
+            if (view.getVisibility() == View.VISIBLE) {
                 displaySnackbar(view, options, callback);
             } else {
-                throw new Error("Content view is not in focus or not visible");
+                Log.w(REACT_NAME, "Content view is not in focus or not visible");
             }
+
             return;
         }
 


### PR DESCRIPTION
Fixes issue where an external view has focus, as discussed in #132. Resolves #132.