### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/RNSnackbar.podspec
+++ b/RNSnackbar.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files        = 'ios/**/*.{h,m}'
   s.exclude_files       = 'android/**/*'
   s.exclude_files       = 'example/**/*'
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
This PR fixes a compatibility issue with Xcode 12. React Native libraries should depend on `React-Core` instead of `React`.

For more details take a look at https://github.com/facebook/react-native/issues/29633#issuecomment-694187116