### PR TITLE
Update SnackbarModule.java

### DIFF
--- a/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
+++ b/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
@@ -126,7 +126,7 @@ public class SnackbarModule extends ReactContextBaseJavaModule {
         }
         View snackbarView = snackbar.getView();
 
-        TextView textView = (TextView) snackbarView.findViewById(android.support.design.R.id.snackbar_text);
+        TextView textView = (TextView) snackbarView.findViewById(com.google.android.material.R.id.snackbar_text);
         textView.setMaxLines(numberOfLines);
 
         if (rtl && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {


### PR DESCRIPTION
I had an issue with bundling android with this error: 
![изображение](https://user-images.githubusercontent.com/59048898/103335572-59f16f00-4a86-11eb-8ed5-a8eb794ad1a0.png)
`***/node_modules/react-native-snackbar/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java:129: error: package android.support.design.R does not exist
        TextView textView = (TextView) snackbarView.findViewById(android.support.design.R.id.snackbar_text);`

So I replaced import from native component (that seemed to be deprecated, cause some lines below there was another import with the same code). See this issue https://stackoverflow.com/questions/53606878/androidx-package-android-support-design-r-does-not-exist 

After that, everything worked fine