### PR TITLE
Fix Android X compatibility issue and DRY code

### DIFF
--- a/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
+++ b/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
@@ -126,15 +126,13 @@ public class SnackbarModule extends ReactContextBaseJavaModule {
         }
         View snackbarView = snackbar.getView();
 
-        TextView textView = (TextView) snackbarView.findViewById(android.support.design.R.id.snackbar_text);
-        textView.setMaxLines(numberOfLines);
-
         if (rtl && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
             snackbarView.setLayoutDirection(View.LAYOUT_DIRECTION_RTL);
             snackbarView.setTextDirection(View.TEXT_DIRECTION_RTL);
         }
 
         TextView snackbarText = snackbarView.findViewById(com.google.android.material.R.id.snackbar_text);
+        snackbarText.setMaxLines(numberOfLines);
         snackbarText.setTextColor(textColor);
 
         if (font != null) {


### PR DESCRIPTION
This PR:

- Fixes build time error (closes #175) when used with RN >= 0.60
- Improves efficiency: removes unnecessary use of inefficient `findViewById`
- DRY code