### PR TITLE
Fix Android bug to show Snackbar over multiple modals rendered

### DIFF
--- a/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
+++ b/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Collections;
 
 public class SnackbarModule extends ReactContextBaseJavaModule {
 
@@ -67,6 +68,9 @@ public class SnackbarModule extends ReactContextBaseJavaModule {
         if (!view.hasWindowFocus()) {
             // Get all modal views on the screen.
             ArrayList<View> modals = recursiveLoopChildren(view, new ArrayList<View>());
+
+            // Reverse array in order to get first the last modal rendered.
+            Collections.reverse(modals);
 
             for (View modal : modals) {
                 if (modal == null) continue;


### PR DESCRIPTION
Hi @cooperka, i was facing the not common scenario trying to render Snackbar over multiple modals.

On iOS devices issue in not reproducible.

On Android instead, when multiple modals were rendered, snackbar is showing behind modala (only over the first modal dispatched).
Seems like chages made on [this fix](https://github.com/cooperka/react-native-snackbar/pull/17) were not completely correct. The order of modals view added on the ArrayList should be reverse.

I've tested and now is working fine on both iOS and Android devices.

Hope it helps!
Manuel.