### PR TITLE
Fix for crash when there's no superview

### DIFF
--- a/ios/RNSnackBarView.m
+++ b/ios/RNSnackBarView.m
@@ -280,7 +280,15 @@ static const NSTimeInterval ANIMATION_DURATION = 0.250;
     NSNumber *duration =
         _pendingOptions[@"duration"] ? (NSNumber *)_pendingOptions[@"duration"] : @(-1);
 
-    [self presentWithDuration:duration];
+
+   @try {
+     [self presentWithDuration:duration];
+   }
+   @catch (NSException *exception) {
+     NSLog(@"%@", exception.reason);
+   }
+
+    
 }
 
 @end


### PR DESCRIPTION
fix for crash when there's no superview.
(Haven't tested this yet. should work fine as the exception from present will bubble up and be caught)

Fixes #192 