### PR TITLE
Fix superview issue on iOS

### DIFF
--- a/ios/RNSnackBarView.m
+++ b/ios/RNSnackBarView.m
@@ -75,7 +75,7 @@ static const NSTimeInterval ANIMATION_DURATION = 0.250;
     CGFloat bottomPadding = topPadding;
 
     if (@available(iOS 11.0, *)) {
-        UIWindow *window = UIApplication.sharedApplication.keyWindow;
+        UIWindow *window = [[UIApplication sharedApplication] delegate].window;
 
         if (window.safeAreaInsets.bottom > bottomPadding)
             bottomPadding = window.safeAreaInsets.bottom;
@@ -182,7 +182,7 @@ static const NSTimeInterval ANIMATION_DURATION = 0.250;
 - (void)presentWithDuration:(NSNumber *)duration {
     _pendingOptions = nil;
     _pendingCallback = nil;
-    UIWindow *keyWindow = [UIApplication sharedApplication].keyWindow;
+    UIWindow *keyWindow = [[UIApplication sharedApplication] delegate].window;
     [keyWindow addSubview:self];
     [self setTranslatesAutoresizingMaskIntoConstraints:false];
     [keyWindow addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[self(>=48)]|"


### PR DESCRIPTION
Fixes #192

current the lib access UIWindow access by
`UIWindow *keyWindow = [UIApplication sharedApplication].keyWindow;`
and was deprecated in ios 15 and can return nil https://developer.apple.com/forums/thread/695932
and when I debugged this and passed
`UIWindow *keyWindow = nil;`
it threw the exact error
`Unable to parse constraint format: Unable to interpret '|' character, because the related view doesn't have a superview V:[self(>=48)]| ^`

By accessing UIWindow by
`UIWindow *keyWindow = [[UIApplication sharedApplication] delegate].window;`
which would point to the window of AppDelegagte.

We didn't saw any crash reports after this fix.