### PR TITLE
Create mock for jest tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,17 @@ Where event is one of the following options :
 | `Snackbar.DISMISS_EVENT_CONSECUTIVE` | `number` | 4 | Indicates that the Snackbar was dismissed from a new Snackbar being shown. |
 | `Snackbar.SHOW_EVENT` | `number` | 5 | Indicates that Snackbar appears |
 
+## Mocking via jest
+
+This package uses NativeModules, which `jest` does not have access to.
+
+You can use the provided mocks in your `jest.setup.js`:
+
+```js
+import mockSnackbar from 'react-native-snackbar/jest/snackbar-mock.js'
+
+jest.mock('react-native-snackbar', () => mockSnackbar);
+```
 
 ## Troubleshooting
 

--- a/jest/snackbar-mock.js
+++ b/jest/snackbar-mock.js
@@ -1,0 +1,14 @@
+/**
+ * @format
+ */
+/* eslint-env jest */
+
+const RNSnackbar = {
+  LENGTH_SHORT: 5,
+  LENGTH_LONG: 10,
+  LENGTH_INDEFINITIE: -1,
+  show: jest.fn(),
+  dismiss: jest.fn(),
+};
+
+module.exports = RNSnackbar;


### PR DESCRIPTION
Adds an exported helper mock. Super basic, but clears up any confusion for users.

Happy to help with changes / maintaining if it helps. Thank you for a great package!