### PR TITLE
Add horizontal margin

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Shows a Snackbar, dismissing any existing Snackbar first. Accepts an object with
 | `duration` | See below | `Snackbar.LENGTH_SHORT` | How long to display the Snackbar. |
 | `numberOfLines` | `number` | `2` | The max number of text lines to allow before ellipsizing. |
 | `marginBottom` | `number` | `0` | Margin from bottom. |
+| `marginHorizotal` | `number` | `0` | Horizontal margins. |
 | `textColor` | `string` or `style` | `'white'` | The color of the message text. |
 | `backgroundColor` | `string` or `style` | `undefined` (dark gray) | The background color for the whole Snackbar. |
 | `fontFamily` | `string` | `undefined` | The basename of a `.ttf` font from `assets/fonts/` (see [setup guide](https://github.com/facebook/react-native/issues/25852) and [example app](/example), remember to `react-native link` after). |

--- a/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
+++ b/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
@@ -9,6 +9,7 @@ import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.FrameLayout;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
@@ -142,6 +143,7 @@ public class SnackbarModule extends ReactContextBaseJavaModule {
         boolean textAlignCenter = getOptionValue(options, "textAlignCenter", false);
         boolean rtl = getOptionValue(options, "rtl", false);
         int marginBottom = getOptionValue(options, "marginBottom", 0);
+        int marginHorizontal = getOptionValue(options, "marginHorizontal", 0);
         String fontFamily = getOptionValue(options, "fontFamily", null);
         Typeface font = null;
         if (fontFamily != null) {
@@ -176,6 +178,16 @@ public class SnackbarModule extends ReactContextBaseJavaModule {
 
         if (marginBottom != 0) {
             snackbarView.setTranslationY(-(convertDpToPixel(marginBottom, snackbarView.getContext())));
+        }
+
+        if (marginHorizontal != 0) {
+            final FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) snackbarView.getLayoutParams();
+            int sideMargin = (int) convertDpToPixel(marginHorizontal, snackbarView.getContext());
+            params.setMargins(params.leftMargin + sideMargin,
+                    params.topMargin,
+                    params.rightMargin + sideMargin,
+                    params.bottomMargin);
+            snackbarView.setLayoutParams(params);
         }
 
         TextView snackbarText = snackbarView.findViewById(com.google.android.material.R.id.snackbar_text);

--- a/ios/RNSnackBarView.m
+++ b/ios/RNSnackBarView.m
@@ -32,6 +32,7 @@ static const NSTimeInterval ANIMATION_DURATION = 0.250;
 @property(nonatomic, strong) NSString *actionText;
 @property(nonatomic, strong) UIColor *actionTextColor;
 @property(nonatomic, strong) NSNumber *marginBottom;
+@property(nonatomic, strong) NSNumber *marginHorizontal;
 @property(nonatomic, strong) NSString *fontFamily;
 @property(nonatomic) BOOL isRTL;
 @property(nonatomic, strong) NSArray<NSLayoutConstraint *> *verticalPaddingConstraints;
@@ -225,10 +226,10 @@ static const NSTimeInterval ANIMATION_DURATION = 0.250;
                                                                       options:0
                                                                       metrics:nil
                                                                         views:@{@"self" : self}]];
-    [keyWindow addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[self]|"
-                                                                      options:0
-                                                                      metrics:nil
-                                                                        views:@{@"self" : self}]];
+    [keyWindow addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:[NSString stringWithFormat:@"H:|-%@-[self]-%@-|", self.marginHorizontal, self.marginHorizontal]
+                                                                   options:0
+                                                                   metrics:nil
+                                                                     views:@{@"self" : self}]];
 
     // Snackbar will slide up from bottom, unless a bottom margin is set in which case we use a fade animation
     self.transform = CGAffineTransformMakeTranslation(0, [self.marginBottom integerValue] == 0 ? self.bounds.size.height : 0);
@@ -304,6 +305,7 @@ static const NSTimeInterval ANIMATION_DURATION = 0.250;
     self.numberOfLines = [RCTConvert int:numberOfLines] ? [RCTConvert int:numberOfLines] : 2;
     
     self.marginBottom = _pendingOptions[@"marginBottom"] ? _pendingOptions[@"marginBottom"] : @(0);
+    self.marginHorizontal = _pendingOptions[@"marginHorizontal"] ? _pendingOptions[@"marginHorizontal"] : @(0);
     
     id backgroundColor = _pendingOptions[@"backgroundColor"];
     self.backgroundColor = backgroundColor ? [RCTConvert UIColor:backgroundColor]

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -36,6 +36,11 @@ export interface SnackBarOptions {
   numberOfLines?: number;
 
   /**
+   * Align text center
+   */
+  textAlignCenter?: boolean;
+
+  /**
    * Length of time the Snackbar stays on screen.
    * Must be one of Snackbar.LENGTH_SHORT, Snackbar.LENGTH_LONG, or Snackbar.LENGTH_INDEFINITE.
    */
@@ -45,6 +50,11 @@ export interface SnackBarOptions {
    * Margin from bottom, defaults to 0.
    */
   marginBottom?: number;
+
+  /**
+   * Margin horizontal, defaults to 0.
+   */
+  marginHorizontal?: number;
 
   /**
    * Snackbar text color.
@@ -70,13 +80,13 @@ export interface SnackBarOptions {
 
   /**
    * Rtl the snackbar
-   * 
-   * [Android only, API 17+] Whether the Snackbar should render right-to-left 
+   *
+   * [Android only, API 17+] Whether the Snackbar should render right-to-left
    * @requires `android:supportsRtl="true"`
    * @see https://android-developers.googleblog.com/2013/03/native-rtl-support-in-android-42.html
    * @see https://github.com/MortezaHeydari97/react-native-snackbar/blob/main/example
    */
-  rtl?: boolean
+  rtl?: boolean;
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { NativeModules, processColor } from 'react-native';
+import { NativeModules, processColor } from "react-native";
 
 /**
  * An optional, actionable button on the Snackbar.
@@ -53,6 +53,11 @@ type SnackBarOptions = {
    * Margin from bottom, defaults to 0.
    */
   marginBottom?: number,
+
+  /**
+   * Margin horizontal, defaults to 0.
+   */
+  marginHorizontal?: number,
 
   /**
    * Snackbar text color.
@@ -149,8 +154,8 @@ const SnackBar: ISnackBar = {
   SHOW_EVENT: NativeModules.RNSnackbar.SHOW_EVENT,
 
   show(options: SnackBarOptions) {
-    warnDeprecation(options, 'title', 'text');
-    warnDeprecation(options, 'color', 'textColor');
+    warnDeprecation(options, "title", "text");
+    warnDeprecation(options, "color", "textColor");
 
     const text = options.text || options.title;
     const { numberOfLines } = options;
@@ -160,19 +165,21 @@ const SnackBar: ISnackBar = {
     // eslint-disable-next-line no-param-reassign
     delete options.color;
     const textColor = textColorRaw && processColor(textColorRaw);
-    const backgroundColor = options.backgroundColor && processColor(options.backgroundColor);
+    const backgroundColor =
+      options.backgroundColor && processColor(options.backgroundColor);
     const textAlignCenter = options.textAlignCenter || false;
 
     const action = options.action || {};
 
-    warnDeprecation(action, 'title', 'text');
-    warnDeprecation(action, 'color', 'textColor');
+    warnDeprecation(action, "title", "text");
+    warnDeprecation(action, "color", "textColor");
 
     const actionText = action.text || action.title;
     delete action.title;
     const actionTextColorRaw = action.textColor || action.color;
     delete action.color;
-    const actionTextColor = actionTextColorRaw && processColor(actionTextColorRaw);
+    const actionTextColor =
+      actionTextColorRaw && processColor(actionTextColorRaw);
     const onPressCallback = action.onPress || (() => {});
 
     const nativeOptions = {
@@ -182,11 +189,13 @@ const SnackBar: ISnackBar = {
       numberOfLines,
       backgroundColor,
       textAlignCenter,
-      action: options.action ? {
-        ...action,
-        text: actionText,
-        textColor: actionTextColor,
-      } : undefined,
+      action: options.action
+        ? {
+            ...action,
+            text: actionText,
+            textColor: actionTextColor,
+          }
+        : undefined,
     };
 
     NativeModules.RNSnackbar.show(nativeOptions, onPressCallback);
@@ -199,7 +208,9 @@ const SnackBar: ISnackBar = {
 
 function warnDeprecation(options, deprecatedKey, newKey) {
   if (options && options[deprecatedKey]) {
-    console.warn(`The Snackbar '${deprecatedKey}' option has been deprecated. Please switch to '${newKey}' instead.`);
+    console.warn(
+      `The Snackbar '${deprecatedKey}' option has been deprecated. Please switch to '${newKey}' instead.`
+    );
   }
 }
 


### PR DESCRIPTION
This PR will re-add this feature since the old implementation on Android (which the previous PR that removed it mentioned [here](https://github.com/cooperka/react-native-snackbar/pull/186)) has been working reliably again since MUI version 1.6 on Android. And it is already packed with RN version 0.73.1, which is kinda long ago.
Also, I implemented it on iOS too
https://github.com/material-components/material-components-android/releases/tag/1.6.0
https://github.com/material-components/material-components-android/commit/d5856fd0365b4daeb27f07c8864d88618884dfb8
